### PR TITLE
multiple subscriptions and disk inventory

### DIFF
--- a/azurevm-inventory.ps1
+++ b/azurevm-inventory.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
     azurevm-inventory.ps1
 .VERSION
-    1.0
+    1.1
 .DESCRIPTION
     List all the VMs in a Azure subscription
 .NOTES
@@ -22,7 +22,6 @@
 #$VerbosePreference = 'Continue'
 $datetime = $((Get-Date).ToString('yyyy-MM-dd_hh-mm-ss'))
 $outputpath = "$env:USERPROFILE\Documents\Reports\Azure\VMs"
-$vms = Get-AzVM
 
 # Controls if warning messages for breaking changes are displayed or suppressed
 Update-AzConfig -DisplayBreakingChangeWarning $false
@@ -30,7 +29,8 @@ Update-AzConfig -DisplayBreakingChangeWarning $false
 If ( -Not (Test-Path -Path $outputPath)) {
     New-Item -ItemType directory -Path $outputPath
 }
- 
+
+Push-Location
 Set-Location $outputPath
 $outputfile = "Inventory-AzureVMs-$dateTime"
 
@@ -56,112 +56,126 @@ else {
     Write-Verbose "No upgrade of the AZ module needed"
 }
 
-
 # Import Module
-Import-Module Az -DisableNameChecking
+Import-Module Az.Accounts -DisableNameChecking
+Import-Module Az.Compute -DisableNameChecking
+Import-Module Az.Network -DisableNameChecking
 
 # Azure Login
-Write-Verbose "Connecting to Azure Account" 
-try {
-    Connect-AzAccount 
-    Write-Verbose "Connected to Azure" 
-}
-catch {
-    Write-Verbose "Failed to connect to Azure. Exit script" 
-    StopIteration
-    Exit 1
+if (-not (Get-AzContext)){
+	Write-Verbose "Connecting to Azure Account" 
+	try {
+		Connect-AzAccount 
+		Write-Verbose "Connected to Azure" 
+	}
+	catch {
+		Write-Verbose "Failed to connect to Azure. Exit script" 
+		StopIteration
+		Exit 1
+	}
 }
 
 # Select Subscription
-Get-AzSubscription | Out-GridView -PassThru -Title "Select Suibscription" | Select-AzSubscription
+$subscriptions = [array](Get-AzSubscription | Out-GridView -PassThru -Title "Select Subscription")
 
-# VM Inventory
 $object = @()
-foreach ($vm in $vms) {
-    $name = $vm.Name
-    $location = $vm.Location
-    # VM Statuses
-    $vm_status = Get-AzVm -ResourceGroupName $vm.ResourceGroupName -name $vm.Name -Status
-    $powerstate = $vm_status.Statuses[1].DisplayStatus
-    $hypergeneration = $vm_status.HyperVGeneration
-    $licensetype = $vm.LicenseType
-    $resourcegroupname = $vm.ResourceGroupName
-    $vmsize = $vm.HardwareProfile.VmSize
-    # Get the type, number of Cores, Memory and OSDisksize
-    $vmsizing = Get-AzVMSize -VMName $vm.Name -ResourceGroupName $vm.ResourceGroupName | Where-Object {$_.Name -eq $vmsize}
-    $cores = $vmsizing.NumberOfCores
-    $memory = $vmsizing.MemoryInMB
-    # Disks
-    $osdisk = $vm.StorageProfile.OsDisk
-    $osdisk_caching = $vm.StorageProfile.OsDisk.Caching
-    $datadiskcount = $vm.StorageProfile.DataDisks.count
-    $disknames = $vm.StorageProfile.DataDisks.Name
-    
-    if ($disknames -ne 0) {
-            $datadisks = $disknames -join ","
-        } 
-    else {
-            $datadisks = "No data disks attached."
-        }
-    
-    # Boot Diagnostics
-    $bootDiagnosticStatus = $vm.DiagnosticsProfile.BootDiagnostics.Enabled
-    $bootDiagnosticsStorageAccount = $vm.DiagnosticsProfile.BootDiagnostics.StorageUri
 
-    $os = $vm.StorageProfile.OsDisk.OsType
-    $offer = $vm.StorageProfile.ImageReference.Offer
-    $sku = $vm.StorageProfile.ImageReference.Sku
-    $publisher = $vm.StorageProfile.ImageReference.Publisher
-    $os_name = $vm_status.OsName
-    $os_version = $vm_status.OsVersion
-    # Network
-    $nicname = $vm.NetworkProfile.NetworkInterfaces.Id.Split("/")[-1]
-    $vmnic = Get-AzNetworkInterface -Name $nicname
-    $private_ip = $vmnic.IpConfigurations.PrivateIpAddress
-    $vnet = $vmnic.IpConfigurations[0].Subnet.Id.Split("/")[8]
-    # Public IP
-    $vmnicName = $vm.NetworkProfile.NetworkInterfaces.Id.Split("/")[8]
-    $publicipAddress = Get-AzPublicIpAddress | Where-Object {$_.IpConfiguration.Id -like "*$vmNicName*"}
-    $tags = ($vm.Tags | ConvertTo-json) ;
-    $vmcreated = $vm.TimeCreated
+foreach ($subscription in $subscriptions){
 
-    $vmObject = [PSCustomObject]@{
-        "Name" = $name
-        "PowerState"= $powerstate
-        "Region" = $location
-        "Resource Group" = $resourcegroupname
-        "VM Size" = $vmsize
-        "CPU_Cores" = $cores
-        "MemoryMB" = $memory
-        "License Type" = $licensetype
-        "OS" = $os
-        "Offer" = $offer 
-        "SKU" = $sku
-        "Publisher" = $publisher
-        "VM Gen" = $hypergeneration
-        "Zone" = $vm.Zones
-        "VM Agent Version" = $vm_status.VMAgent.VmAgentVersion
-        "OS_Name" = $os_name
-        "OS_Version" = $os_version
-        "NIC_Name" = $nicname
-        "VNet" = $vnet
-        "Private_IP" = $private_ip
-        "Public_IP" = $publicipAddress.IpAddress
-        "OS_Disk_Name" = $osdisk.Name
-        "OS_Disk_Size_GB" = $osdisk.DiskSizeGB
-        "OS_Storage_Type" = $osdisk.ManagedDisk.StorageAccountType
-        "OS_Disk_Caching" = $osdisk_caching
-        "Datadisks_Count" = $datadiskcount 
-        "Datadisks" =  $datadisks
-        "Admin UserName" = $vm.OSProfile.AdminUsername
-        "Bootdiagnostics_Enabled" = $bootDiagnosticStatus
-        "Bootdiag_StorageAccount" = $bootDiagnosticsStorageAccount
-        "Tags" = $tags
-        "VM Created" = $vmcreated
-    }
-    $object += $vmObject 
+	# Make the subscription the active subscription
+	$subscription | Select-AzSubscription
+
+	# VM Inventory
+	$vms = Get-AzVM
+	foreach ($vm in $vms) {
+		$name = $vm.Name
+		$location = $vm.Location
+		# VM Statuses
+		$vm_status = Get-AzVm -ResourceGroupName $vm.ResourceGroupName -name $vm.Name -Status
+		$powerstate = $vm_status.Statuses[1].DisplayStatus
+		$hypergeneration = $vm_status.HyperVGeneration
+		$licensetype = $vm.LicenseType
+		$resourcegroupname = $vm.ResourceGroupName
+		$vmsize = $vm.HardwareProfile.VmSize
+		# Get the type, number of Cores, Memory and OSDisksize
+		$vmsizing = Get-AzVMSize -VMName $vm.Name -ResourceGroupName $vm.ResourceGroupName | Where-Object {$_.Name -eq $vmsize}
+		$cores = $vmsizing.NumberOfCores
+		$memory = $vmsizing.MemoryInMB
+		# Disks
+		$osdisk = $vm.StorageProfile.OsDisk
+		$osdisk_caching = $vm.StorageProfile.OsDisk.Caching
+		$datadiskcount = $vm.StorageProfile.DataDisks.count
+		$disknames = $vm.StorageProfile.DataDisks.Name
+		
+		if ($disknames -ne 0) {
+				$datadisks = $disknames -join ","
+			} 
+		else {
+				$datadisks = "No data disks attached."
+			}
+		
+		# Boot Diagnostics
+		$bootDiagnosticStatus = $vm.DiagnosticsProfile.BootDiagnostics.Enabled
+		$bootDiagnosticsStorageAccount = $vm.DiagnosticsProfile.BootDiagnostics.StorageUri
+
+		$os = $vm.StorageProfile.OsDisk.OsType
+		$offer = $vm.StorageProfile.ImageReference.Offer
+		$sku = $vm.StorageProfile.ImageReference.Sku
+		$publisher = $vm.StorageProfile.ImageReference.Publisher
+		$os_name = $vm_status.OsName
+		$os_version = $vm_status.OsVersion
+		# Network
+		$nicname = $vm.NetworkProfile.NetworkInterfaces.Id.Split("/")[-1]
+		$vmnic = Get-AzNetworkInterface -Name $nicname
+		$private_ip = $vmnic.IpConfigurations.PrivateIpAddress
+		$vnet = $vmnic.IpConfigurations[0].Subnet.Id.Split("/")[8]
+		# Public IP
+		$vmnicName = $vm.NetworkProfile.NetworkInterfaces.Id.Split("/")[8]
+		$publicipAddress = Get-AzPublicIpAddress | Where-Object {$_.IpConfiguration.Id -like "*$vmNicName*"}
+		$tags = ($vm.Tags | ConvertTo-json) ;
+		$vmcreated = $vm.TimeCreated
+
+		$vmObject = [PSCustomObject]@{
+			"Subscription" = $subscription.Name
+			"Name" = $name
+			"PowerState"= $powerstate
+			"Region" = $location
+			"Resource Group" = $resourcegroupname
+			"VM Size" = $vmsize
+			"CPU_Cores" = $cores
+			"MemoryMB" = $memory
+			"License Type" = $licensetype
+			"OS" = $os
+			"Offer" = $offer 
+			"SKU" = $sku
+			"Publisher" = $publisher
+			"VM Gen" = $hypergeneration
+			"Zone" = $vm.Zones
+			"VM Agent Version" = $vm_status.VMAgent.VmAgentVersion
+			"OS_Name" = $os_name
+			"OS_Version" = $os_version
+			"NIC_Name" = $nicname
+			"VNet" = $vnet
+			"Private_IP" = $private_ip
+			"Public_IP" = $publicipAddress.IpAddress
+			"OS_Disk_Name" = $osdisk.Name
+			"OS_Disk_Size_GB" = $osdisk.DiskSizeGB
+			"OS_Storage_Type" = $osdisk.ManagedDisk.StorageAccountType
+			"OS_Disk_Caching" = $osdisk_caching
+			"Datadisks_Count" = $datadiskcount 
+			"Datadisks" =  $datadisks
+			"Admin UserName" = $vm.OSProfile.AdminUsername
+			"Bootdiagnostics_Enabled" = $bootDiagnosticStatus
+			"Bootdiag_StorageAccount" = $bootDiagnosticsStorageAccount
+			"Tags" = $tags
+			"VM Created" = $vmcreated
+		}
+		$object += $vmObject
+	}
 }
 
 $object
 $object | Out-GridView
 $object | Export-Csv -Path "$Outputfile.csv" -NoTypeInformation -UseCulture
+
+Pop-location


### PR DESCRIPTION
Added a couple of things;

- Changed the environment path to the actual documents folder as the original path will not work once anyone has relocated the documents folder.
- Keeping the original folder where the script is ran from as oppose to leaving the user in the reports folder
- Specified the AZ modules we need instead of the entire thing. Speeds up the process a bit.
- Checking if we are already logged in.
- Grabbing the subscriptions and looping through them when the user selects them all.
- Added a new file for Managed Disk inventory, but this perhaps could be parameterized to select the type of information you want instead of just grabbing the info while we're at it.